### PR TITLE
Expose swallowed exception

### DIFF
--- a/src/main/scala/epic/models/package.scala
+++ b/src/main/scala/epic/models/package.scala
@@ -57,8 +57,8 @@ package object models {
               try {
                 readFromJar("", f)
               } catch {
-                case ex: IOException =>
-                  throw new RuntimeException(s"Could not find model $model in path $path")
+                case ex: Exception =>
+                  throw new RuntimeException(s"Could not find model $model in path $path", ex)
               }
 
           }

--- a/src/main/scala/epic/util/ProcessTextMain.scala
+++ b/src/main/scala/epic/util/ProcessTextMain.scala
@@ -42,6 +42,8 @@ trait ProcessTextMain[Model, AnnotatedType] {
       epic.models.deserialize[Model](params.model.toString)
     } catch {
       case ex: Exception =>
+        // BT 20150514 - skanky hack to get message to screen, would be nicer if could say "enable debug messages for full trace"
+        System.err.println(s"Couldn't deserialize model due to exception, ${ex.getCause.getMessage}. Trying classPathLoad...")
         classPathLoad(params.model.toString)
     }
 


### PR DESCRIPTION
Expose swallowed exception that was hiding an java.io.InvalidClassException during deserialization. 

Would like to follow on with moving output to Java logging or slf4j. It would be a great way for me to get familiar with the code and give back something at the same time. The code that I patched here has an "expected" exception that fires off a call to ```classPathLoad```, but in this case, only an ```IOException``` was expected, so it wasn't caught or logged, resulting in another error that could have been anything. This is one of the challenges with using runtime exceptions, but it's pretty easy to just put in a top-level exception handler to dump the trace as well.