### PR TITLE
fix example parser render code

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ val parser = epic.models.ParserSelector.loadParser("en").get // or another 2 let
 
 val tree = parser(sentence)
 
-println(tree.render(words))
+println(tree.render(sentence))
 
 ```
 
@@ -112,7 +112,7 @@ println(tags.render)
 
 #### Named Entity Recognition
 
-Using a named entity recognizer is similar to using a pos tagger: load a model, tokenize some text, run the recognizer. All NER systems are (currently) [linear chain semi-Markov conditional random fields](http://people.cs.umass.edu/~mccallum/papers/crf-tutorial.pdf), or SemiCRFs. (You don't need to understand them to use them. They are just a machine learning method for segmenting text into fields.
+Using a named entity recognizer is similar to using a pos tagger: load a model, tokenize some text, run the recognizer. All NER systems are (currently) [linear chain semi-Markov conditional random fields](http://people.cs.umass.edu/~mccallum/papers/crf-tutorial.pdf), or SemiCRFs. (You don't need to understand them to use them. They are just a machine learning method for segmenting text into fields.)
 
 ```scala
 val ner = epic.models.deserialize[SemiCRF[AnnotatedLabel, String]](path)


### PR DESCRIPTION
The variable to use was sentence, not words. Bonus: an unmatched parenthesis