### PR TITLE
Remove while space only sentences in NewLineSentenceSegmenter

### DIFF
--- a/src/main/scala/epic/preprocess/NewLineSentenceSegmenter.scala
+++ b/src/main/scala/epic/preprocess/NewLineSentenceSegmenter.scala
@@ -14,7 +14,8 @@ class NewLineSentenceSegmenter(locale: Locale = Locale.getDefault) extends Sente
   private val regex = Pattern.compile("\n+")
 
   override def apply[In](slab: StringSlab[In]): StringSlab[In with Sentence] = {
-    val m = regex.matcher(slab.content)
+    val text = slab.content
+    val m = regex.matcher(text)
 
     val spans = new ArrayBuffer[(Span, Sentence)]()
 
@@ -25,9 +26,9 @@ class NewLineSentenceSegmenter(locale: Locale = Locale.getDefault) extends Sente
         spans += (Span(start, end) -> Sentence())
       start = end
     }
-    spans += Span(start, slab.content.length) -> Sentence()
+    spans += Span(start, text.length) -> Sentence()
 
-    slab.addLayer[Sentence](spans)
+    slab.addLayer[Sentence](spans.filterNot(s => text.substring(s._1.begin, s._1.end).forall(_.isWhitespace)))
   }
 }
 


### PR DESCRIPTION
`NewLineSentenceSegmenter` did not trim each segmented sentence, so for example, it always outputted an error:

```
$ echo I live in Osaka . | java -Xmx4g -cp assembly.jar epic.parser.ParseText --model parsers/SpanModel-300.parser --sentences newline --tokens whitespace
(TOP (S (NP (PRP He) ) (VP (VBZ lives)  (PP (IN in)  (NP (NNP Osaka) )))))
### Could not tag Vector(), because No parse for Vector(): infinite partition... epic.parser.projections.ChartProjector$class.project(ChartProjector.scala:36);epic.parser.projections.AnchoredRuleMarginalProjector.project(EnumeratedAnchoring.scala:78)
```

I added an filter for empty sentences as in `MLSentenceSegmenter`, which avoids this by trimming every sentence. Now no error is outputted.