### PR TITLE
Remove 2.11 scalaVersion to fix 2.12 build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val VersionRegex = "v([0-9]+.[0-9]+.[0-9]+)-?(.*)?".r
 
 lazy val commonSettings = Seq(
   organization := "org.scalanlp",
-  version := "0.4.4",
+  version := "0.4.5",
   /*
   git.baseVersion := "0.4",
   // append -SNAPSHOT unless we're on a branch
@@ -44,8 +44,7 @@ lazy val commonSettings = Seq(
     }
   },
   */
-  scalaVersion := Version.scala,
-  crossScalaVersions := Seq("2.12.1", "2.11.8"),
+  crossScalaVersions := Seq("2.12.10", "2.11.8"),
   libraryDependencies ++= Seq(
     Library.breeze,
     Library.breezeConfig,
@@ -80,11 +79,7 @@ lazy val commonSettings = Seq(
     "Scala Tools Snapshots" at "http://scala-tools.org/repo-snapshots/",
     "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
   ),
-  libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, scalaMajor)) if scalaMajor >= 12 => Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
-      case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
-      case _ => Seq.empty
-      })
+  libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
   ) ++ sbtjflex.SbtJFlexPlugin.jflexSettings
   // ++ net.virtualvoid.sbt.graph.Plugin.graphSettings
   

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,6 @@
 import sbt._
 
 object Version {
-  val scala               = "2.11.8"
   val scalaTest           = "3.0.1"
   val breeze              = "0.13"
   val breezeConfig        = "0.9.2"


### PR DESCRIPTION
Running Epic 0.4.4 on Scala 2.12, I'm running into errors like this:

```
... snip ...
Caused by: java.lang.BootstrapMethodError: java.lang.NoSuchMethodError: scala.Array$.$anonfun$fill$1$adapted(Lscala/Array$;ILscala/Function0;Lscala/reflect/ClassTag;Ljava/lang/Object;)Ljava/lang/Object;
    at epic.sequences.CRF$.viterbi(CRF.scala:309)
    at epic.sequences.CRF.bestSequence(CRF.scala:42)
    at epic.sequences.CRF.bestSequence$(CRF.scala:41)
    at epic.sequences.CRFInference.bestSequence(CRFModel.scala:58)
    at ... snip ...
    ... 45 more
Caused by: java.lang.NoSuchMethodError: scala.Array$.$anonfun$fill$1$adapted(Lscala/Array$;ILscala/Function0;Lscala/reflect/ClassTag;Ljava/lang/Object;)Ljava/lang/Object;
    at java.lang.invoke.MethodHandleNatives.resolve(Native Method)
    at java.lang.invoke.MemberName$Factory.resolve(MemberName.java:975)
    at java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1000)
    at java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:1394)
    at java.lang.invoke.MethodHandles$Lookup.linkMethodHandleConstant(MethodHandles.java:1750)
    at java.lang.invoke.MethodHandleNatives.linkMethodHandleConstant(MethodHandleNatives.java:477)
    ... 68 more
```

The error is consistent with having Scala 2.11 on the classpath of a 2.12 bulid. Epic has `scalaVersion := 2.11` along with `crossScalaVersions` which upon removing fixes my classpath issue.

I also bumped 2.12 to the latest (2.12.10) and simplified the scala-xml expression without the scalaVersion match.
